### PR TITLE
Added redis server as a dependency to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ V2 detects and repairs instances of configuration drift in Python snippets.
 | Node.js        | 12.1.0  |
 | Docker         | 18.09.2 |
 | Docker Compose | 1.23.2  |
+| Redis Server   | 5.0.7   |
 
 ## Setup
 


### PR DESCRIPTION
In order to run V2 successfully installing a Redis server is required.
(E.g. on Ubuntu 20.04 LTS run 'apt install redis-server')
This bit of information is (so far) missing in the 'Dependencys' section of 'README.md' and is added here.